### PR TITLE
ftp to passive mode and changed filepath

### DIFF
--- a/src/main/java/dev/espi/ebackup/BackupUtil.java
+++ b/src/main/java/dev/espi/ebackup/BackupUtil.java
@@ -159,7 +159,9 @@ public class BackupUtil {
         try (FileInputStream fio = new FileInputStream(f)) {
             ftpClient.connect(eBackup.getPlugin().ftpHost, eBackup.getPlugin().ftpPort);
             ftpClient.login(eBackup.getPlugin().ftpUser, eBackup.getPlugin().ftpPass);
-            ftpClient.storeFile(f.getAbsolutePath(), fio);
+            ftpClient.enterLocalPassiveMode();
+            ftpClient.setUseEPSVwithIPv4(true);
+            ftpClient.storeFile(f.getName(), fio);
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/src/main/java/dev/espi/ebackup/BackupUtil.java
+++ b/src/main/java/dev/espi/ebackup/BackupUtil.java
@@ -161,6 +161,7 @@ public class BackupUtil {
             ftpClient.login(eBackup.getPlugin().ftpUser, eBackup.getPlugin().ftpPass);
             ftpClient.enterLocalPassiveMode();
             ftpClient.setUseEPSVwithIPv4(true);
+            ftpClient.setFileType(FTP.BINARY_FILE_TYPE);
             ftpClient.storeFile(f.getName(), fio);
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
My ftp server is behind a NAT so i needed the plugin to use ftp passive mode. It wasnt working for me and now it is with this small addition. Also the file wanted to upload to the absolute path of the minecraft server inside the ftp folder so i changed that to just the file name for now