### PR TITLE
Allow filename timestamp custom format

### DIFF
--- a/src/main/java/dev/espi/ebackup/BackupUtil.java
+++ b/src/main/java/dev/espi/ebackup/BackupUtil.java
@@ -84,7 +84,8 @@ public class BackupUtil {
             checkMaxBackups();
 
             // zip
-            String fileName = eBackup.getPlugin().backupFormat.replace("{DATE}", new SimpleDateFormat("yyyy-MM-dd HH-mm-ss").format(new Date()));
+            SimpleDateFormat formatter = new SimpleDateFormat(eBackup.getPlugin().backupDateFormat);
+            String fileName = eBackup.getPlugin().backupFormat.replace("{DATE}", formatter.format(new Date()));
             FileOutputStream fos = new FileOutputStream(eBackup.getPlugin().backupPath + "/" + fileName + ".zip");
             ZipOutputStream zipOut = new ZipOutputStream(fos);
 

--- a/src/main/java/dev/espi/ebackup/eBackup.java
+++ b/src/main/java/dev/espi/ebackup/eBackup.java
@@ -40,7 +40,7 @@ public class eBackup extends JavaPlugin implements CommandExecutor {
 
     // config options
 
-    String crontask, backupFormat;
+    String crontask, backupFormat, backupDateFormat;
     File backupPath;
     int maxBackups;
     boolean deleteAfterUpload;
@@ -75,6 +75,7 @@ public class eBackup extends JavaPlugin implements CommandExecutor {
         // load config data
         crontask = getConfig().getString("crontask");
         backupFormat = getConfig().getString("backup-format");
+        backupDateFormat = getConfig().getString("backup-date-format");
         backupPath = new File(getConfig().getString("backup-path"));
         maxBackups = getConfig().getInt("max-backups");
         deleteAfterUpload = getConfig().getBoolean("delete-after-upload");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,10 @@ crontask: '0 0 4 * * *' # This would make it every day at 4 AM
 # Filename format for the backup files created
 backup-format: 'eBackup {DATE}'
 
+# Format to use as replacement for {DATE} in backup-format
+# Refer to java.text.SimpleDateFormat for format docs
+backup-date-format: 'yyyy-MM-dd HH-mm-ss'
+
 # The folder where to store the backups locally.
 backup-path: 'plugins/eBackup/backups'
 


### PR DESCRIPTION
This PR adds a new configuration param called `backup-date-format` which can be used to customize the date/time format used in the `backup-format` param. If not specified, it defaults to same date format that the plugin currently uses.

First time working on plugins so please forgive any mistakes that might seem obvious :)

I tested this a few different ways
- With the config param omitted from file (like will be the case for all existing users) --> uses default
- config param as empty string --> uses default
- config param with custom format

I generally enjoy writing unit tests for my code but I imagine it's not straightforward when working with the fairly complex Bukkit / Spigot APIs.